### PR TITLE
Expand currency to support multi currency system

### DIFF
--- a/core/src/BUILD.bazel
+++ b/core/src/BUILD.bazel
@@ -2,9 +2,9 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "currency",
-    srcs = [],
+    srcs = ["currency.cpp"],
     hdrs = ["currency.h"],
-    # visibility = ["//core/src/tests:__subpackages__"],
+    visibility = ["//core/src/tests:__subpackages__"],
 )
 
 cc_library(

--- a/core/src/currency.cpp
+++ b/core/src/currency.cpp
@@ -4,9 +4,14 @@
 
 namespace Finances::Core {
 
-constexpr bool is_valid_code(std::string_view code) {
-    return code.size() == 3 && std::isupper(code[0]) && std::isupper(code[1]) && std::isupper(code[2]);
+namespace {
+constexpr auto is_ascii_upper(char c) noexcept { return c >= 'A' && c <= 'Z'; }
+
+constexpr auto is_valid_code(std::string_view code) noexcept {
+    return code.size() == 3 && is_ascii_upper(code[0]) && is_ascii_upper(code[1]) && is_ascii_upper(code[2]);
 }
+
+}  // namespace
 
 Currency::Currency(std::string_view code, int decimals) : code_(code), decimals_(decimals) {
     if (!is_valid_code(code)) {

--- a/core/src/currency.cpp
+++ b/core/src/currency.cpp
@@ -1,0 +1,21 @@
+#include "core/src/currency.h"
+
+#include <stdexcept>
+
+namespace Finances::Core {
+
+constexpr bool is_valid_code(std::string_view code) {
+    return code.size() == 3 && std::isupper(code[0]) && std::isupper(code[1]) && std::isupper(code[2]);
+}
+
+Currency::Currency(std::string_view code, int decimals) : code_(code), decimals_(decimals) {
+    if (!is_valid_code(code)) {
+        throw std::invalid_argument("Currency code must be 3 uppercase letters");
+    }
+
+    if (decimals < 0 || decimals > 6) {
+        throw std::invalid_argument("Currency decimals must be between 0 and 6");
+    }
+}
+
+}  // namespace Finances::Core

--- a/core/src/currency.h
+++ b/core/src/currency.h
@@ -1,7 +1,22 @@
 #pragma once
+#include <compare>
+#include <string>
+#include <string_view>
 
 namespace Finances::Core {
 
-enum class Currency { EUR, USD, BRL, GBP };
+class Currency {
+   public:
+    Currency(std::string_view code, int decimals);
+
+    std::string_view code() const noexcept { return code_; }
+    constexpr int decimals() const noexcept { return decimals_; }
+
+    auto operator<=>(const Currency&) const noexcept = default;
+
+   private:
+    std::string code_;  // ISO 4217 code (e.g., "EUR")
+    int decimals_;      // Number of decimal places (e.g., 2)
+};
 
 }  // namespace Finances::Core

--- a/core/src/money.cpp
+++ b/core/src/money.cpp
@@ -4,7 +4,7 @@
 
 namespace Finances::Core {
 
-Money::Money(long amount, Currency currency) : amount(amount), currency(currency) {
+Money::Money(long amount, const Currency& currency) : amount(amount), currency(currency) {
     if (amount < 0) {
         throw std::invalid_argument("Amount cannot be negative");
     }

--- a/core/src/money.cpp
+++ b/core/src/money.cpp
@@ -10,6 +10,4 @@ Money::Money(long amount, Currency currency) : amount(amount), currency(currency
     }
 }
 
-bool Money::operator==(const Money &other) const = default;
-
 }  // namespace Finances::Core

--- a/core/src/money.h
+++ b/core/src/money.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <compare>
+
 #include "core/src/currency.h"
 
 namespace Finances::Core {
@@ -8,7 +10,7 @@ class Money {
     Currency currency;
 
     Money(long amount, Currency currency);
-    bool operator==(const Money &other) const;
+    auto operator<=>(const Money&) const = default;
 };
 
 }  // namespace Finances::Core

--- a/core/src/money.h
+++ b/core/src/money.h
@@ -9,8 +9,9 @@ class Money {
     long amount;
     Currency currency;
 
-    Money(long amount, Currency currency);
-    auto operator<=>(const Money&) const = default;
+    Money(long amount, const Currency& currency);
+
+    bool operator==(const Money&) const = default;
 };
 
 }  // namespace Finances::Core

--- a/core/src/tests/BUILD.bazel
+++ b/core/src/tests/BUILD.bazel
@@ -1,6 +1,16 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
 
 cc_test(
+    name = "currency_tests",
+    srcs = ["currency_tests.cpp"],
+    tags = ["no_sanitize"],
+    deps = [
+        "//core/src:currency",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "money_tests",
     srcs = ["money_tests.cpp"],
     tags = ["no_sanitize"],

--- a/core/src/tests/currency_tests.cpp
+++ b/core/src/tests/currency_tests.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include "core/src/currency.h"
+
+namespace {
+using Finances::Core::Currency;
+
+TEST(CurrencyTests, ValidConstruction) {
+    Currency eur("EUR", 2);
+    EXPECT_EQ(eur.code(), "EUR");
+    EXPECT_EQ(eur.decimals(), 2);
+}
+
+TEST(CurrencyTests, ValidDecimals) {
+    EXPECT_NO_THROW(Currency eur1("EUR", 0));
+    EXPECT_NO_THROW(Currency eur2("EUR", 2));
+    EXPECT_NO_THROW(Currency eur3("EUR", 6));
+}
+
+TEST(CurrencyTests, InvalidCodeThrows) {
+    EXPECT_THROW(Currency("EU", 2), std::invalid_argument);
+    EXPECT_THROW(Currency("EURO", 2), std::invalid_argument);
+    EXPECT_THROW(Currency("eur", 2), std::invalid_argument);
+}
+
+TEST(CurrencyTests, InvalidDecimalsThrows) {
+    EXPECT_THROW(Currency("EUR", -1), std::invalid_argument);
+    EXPECT_THROW(Currency("EUR", 7), std::invalid_argument);
+}
+
+TEST(CurrencyTests, ComparisonWorks) {
+    Currency eur1("EUR", 2);
+    Currency eur2("EUR", 2);
+    Currency usd("USD", 2);
+
+    EXPECT_TRUE(eur1 == eur2);
+    EXPECT_TRUE(eur1 != usd);
+}
+
+}  // namespace

--- a/core/src/tests/money_tests.cpp
+++ b/core/src/tests/money_tests.cpp
@@ -6,11 +6,11 @@ namespace {
 using namespace Finances::Core;
 
 TEST(MoneyTest, EqualityWorks) {
-    Money a(100, Currency::EUR);
-    Money b(100, Currency::EUR);
+    Money a(100, Currency("EUR", 2));
+    Money b(100, Currency("EUR", 2));
     EXPECT_EQ(a, b);
 }
 
-TEST(MoneyTest, ThrowsOnNegativeAmount) { EXPECT_THROW(Money(-10, Currency::EUR), std::invalid_argument); }
+TEST(MoneyTest, ThrowsOnNegativeAmount) { EXPECT_THROW(Money(-10, Currency("EUR", 2)), std::invalid_argument); }
 
 }  // namespace

--- a/core/src/tests/money_tests.cpp
+++ b/core/src/tests/money_tests.cpp
@@ -11,6 +11,14 @@ TEST(MoneyTest, EqualityWorks) {
     EXPECT_EQ(a, b);
 }
 
+TEST(MoneyTest, InequalityWorks) {
+    Money a(100, Currency("EUR", 2));
+    Money b(200, Currency("EUR", 2));
+    Money c(100, Currency("USD", 2));
+    EXPECT_NE(a, b);
+    EXPECT_NE(a, c);
+}
+
 TEST(MoneyTest, ThrowsOnNegativeAmount) { EXPECT_THROW(Money(-10, Currency("EUR", 2)), std::invalid_argument); }
 
 }  // namespace

--- a/core/src/tests/transaction_tests.cpp
+++ b/core/src/tests/transaction_tests.cpp
@@ -6,7 +6,7 @@ namespace {
 using namespace Finances::Core;
 
 TEST(TransactionTest, CreatesValidTransaction) {
-    Transaction t(TransactionType::Income, Money(100, Currency::EUR), "food", 12345, "Lunch");
+    Transaction t(TransactionType::Income, Money(100, Currency("EUR", 2)), "food", 12345, "Lunch");
 
     EXPECT_EQ(t.amount.amount, 100);
     EXPECT_EQ(t.category_id, "food");
@@ -15,7 +15,7 @@ TEST(TransactionTest, CreatesValidTransaction) {
 }
 
 TEST(TransactionTest, Generates32CharId) {
-    Transaction t(TransactionType::Expense, Money(50, Currency::EUR), "transport", 99999, "Bus");
+    Transaction t(TransactionType::Expense, Money(50, Currency("EUR", 2)), "transport", 99999, "Bus");
 
     EXPECT_EQ(t.id.size(), 32);
 }


### PR DESCRIPTION
#31

Expand currency to support multi currency system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Currency now represented by a runtime construct accepting any ISO-4217 code (exactly 3 uppercase letters) and decimals 0–6; invalid inputs raise exceptions.
  * Money API updated to use the new currency representation.

* **Tests**
  * Added and updated tests covering currency validation, decimals range, exception behavior, comparison, and updated money/transaction tests to use the new currency form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->