### PR TITLE
Configure lint using aspect_rules_lint

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,11 +43,9 @@ build:tsan --linkopt=-fsanitize=thread
 build:tsan --strip=never
 
 # Clang-Tidy build
-build:tidy --features=clang-tidy
-build:tidy --config=debug
-build:tidy --copt=-fno-omit-frame-pointer
-build:tidy --cxxopt=-fno-omit-frame-pointer
-build:tidy --action_env=CLANG_TIDY=external/toolchains_llvm~~llvm~llvm_toolchain/bin/clang-tidy
+build:tidy --compilation_mode=opt
+build:tidy --aspects=//tools/lint:linters.bzl%clang_tidy
+build:tidy --@aspect_rules_lint//lint:fail_on_violation=true
 
 # Debug build
 build:debug --compilation_mode=dbg

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,6 @@ Checks: >
   -google-readability-braces-around-statements,
   -cppcoreguidelines-avoid-magic-numbers
 
-WarningsAsErrors: ''
+WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 FormatStyle:     none

--- a/core/src/tests/BUILD.bazel
+++ b/core/src/tests/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
+load("//tools/lint:linters.bzl", "clang_tidy_test")
 
 cc_test(
     name = "currency_tests",
@@ -8,6 +9,11 @@ cc_test(
         "//core/src:currency",
         "@googletest//:gtest_main",
     ],
+)
+
+clang_tidy_test(
+    name = "currency_lint_test",
+    srcs = ["//core/src:currency"],
 )
 
 cc_test(
@@ -20,6 +26,16 @@ cc_test(
     ],
 )
 
+clang_tidy_test(
+    name = "money_errors_lint_test",
+    srcs = ["//core/src:money_errors"],
+)
+
+clang_tidy_test(
+    name = "money_lint_test",
+    srcs = ["//core/src:money"],
+)
+
 cc_test(
     name = "transaction_tests",
     srcs = ["transaction_tests.cpp"],
@@ -28,4 +44,9 @@ cc_test(
         "//core/src:transaction",
         "@googletest//:gtest_main",
     ],
+)
+
+clang_tidy_test(
+    name = "transaction_lint_test",
+    srcs = ["//core/src:transaction"],
 )

--- a/tools/format/BUILD.bazel
+++ b/tools/format/BUILD.bazel
@@ -4,8 +4,8 @@ package(default_visibility = ["//:__subpackages__"])
 
 format_multirun(
     name = "format",
-    c = "@llvm_toolchain_llvm//:bin/clang-format",
-    cc = "@llvm_toolchain_llvm//:bin/clang-format",
+    c = "@llvm_toolchain//:clang-format",
+    cc = "@llvm_toolchain//:clang-format",
     starlark = "@buildifier_prebuilt//:buildifier",
     visibility = ["//:__subpackages__"],
 )

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+native_binary(
+    name = "clang_tidy",
+    src = "@llvm_toolchain//:clang-tidy",
+    out = "clang_tidy",
+)

--- a/tools/lint/linters.bzl
+++ b/tools/lint/linters.bzl
@@ -1,0 +1,12 @@
+load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
+load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
+
+clang_tidy = lint_clang_tidy_aspect(
+    binary = Label("//tools/lint:clang_tidy"),
+    configs = [Label("//:.clang-tidy")],
+    lint_target_headers = True,
+    angle_includes_are_system = False,
+    verbose = False,
+)
+
+clang_tidy_test = lint_test(aspect = clang_tidy)


### PR DESCRIPTION
This attempt is similar to [this](https://github.com/gabrielfsantos/personal-finances/pull/45), but a bit more organized. Failed in the same way.

One thing was discovered, though: when the linter finds an error, it returns an error and shows the message. That is working fine. The problem is when a warning is found and it should be treated as an error. The linter returns an error but no message is shown. Internally, the error message is kept in a temp file, for example bazel-out/k8-opt/bin/core/src/currency.AspectRulesLintClangTidy.out, and not shown. This attempt failed to show that message.