### PR TITLE
Add wrapper to aspect rules lint

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,11 +43,9 @@ build:tsan --linkopt=-fsanitize=thread
 build:tsan --strip=never
 
 # Clang-Tidy build
-build:tidy --features=clang-tidy
-build:tidy --config=debug
-build:tidy --copt=-fno-omit-frame-pointer
-build:tidy --cxxopt=-fno-omit-frame-pointer
-build:tidy --action_env=CLANG_TIDY=external/toolchains_llvm~~llvm~llvm_toolchain/bin/clang-tidy
+build:tidy --compilation_mode=opt
+build:tidy --aspects=//tools/lint:linters.bzl%clang_tidy
+build:tidy --@aspect_rules_lint//lint:fail_on_violation=true
 
 # Debug build
 build:debug --compilation_mode=dbg

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,6 @@ Checks: >
   -google-readability-braces-around-statements,
   -cppcoreguidelines-avoid-magic-numbers
 
-WarningsAsErrors: ''
+WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 FormatStyle:     none

--- a/tools/format/BUILD.bazel
+++ b/tools/format/BUILD.bazel
@@ -4,8 +4,8 @@ package(default_visibility = ["//:__subpackages__"])
 
 format_multirun(
     name = "format",
-    c = "@llvm_toolchain_llvm//:bin/clang-format",
-    cc = "@llvm_toolchain_llvm//:bin/clang-format",
+    c = "@llvm_toolchain//:clang-format",
+    cc = "@llvm_toolchain//:clang-format",
     starlark = "@buildifier_prebuilt//:buildifier",
     visibility = ["//:__subpackages__"],
 )

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+native_binary(
+    name = "clang_tidy",
+    src = "@llvm_toolchain//:clang-tidy",
+    out = "clang_tidy",
+)

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -5,3 +5,10 @@ native_binary(
     src = "@llvm_toolchain//:clang-tidy",
     out = "clang_tidy",
 )
+
+sh_binary(
+    name = "clang_tidy_runner",
+    srcs = ["clang_tidy_runner.sh"],
+    data = [":clang_tidy"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/lint/clang_tidy_runner.sh
+++ b/tools/lint/clang_tidy_runner.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_LINK="${SCRIPT_DIR}/clang_tidy"
+
+REAL_CLANG_TIDY=""
+
+if [ -e "$TARGET_LINK" ] || [ -L "$TARGET_LINK" ]; then
+    REAL_CLANG_TIDY="$TARGET_LINK"
+else
+    REAL_CLANG_TIDY=$(find "${SCRIPT_DIR}/.." -name "clang_tidy" 2>/dev/null | head -n 1)
+fi
+
+if [ -z "$REAL_CLANG_TIDY" ]; then
+    echo "ERROR: Não foi possível localizar o link/binário do clang_tidy." >&2
+    echo "       Diretório atual de busca: ${SCRIPT_DIR}" >&2
+    exit 1
+fi
+
+TMP_LOG=$(mktemp)
+trap 'rm -f "$TMP_LOG"' EXIT
+
+set +e
+"$REAL_CLANG_TIDY" "$@" > "$TMP_LOG" 2>&1
+EXIT_CODE=$?
+set -e
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "================================================================================" >&2
+    echo " [clang-tidy] Static analysis failed: " >&2
+    echo "================================================================================" >&2
+    cat "$TMP_LOG" >&2
+    echo "================================================================================" >&2
+    exit $EXIT_CODE
+fi
+
+exit 0

--- a/tools/lint/linters.bzl
+++ b/tools/lint/linters.bzl
@@ -1,0 +1,12 @@
+load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
+load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
+
+clang_tidy = lint_clang_tidy_aspect(
+    binary = Label("//tools/lint:clang_tidy"),
+    configs = [Label("//:.clang-tidy")],
+    lint_target_headers = True,
+    angle_includes_are_system = False,
+    verbose = False,
+)
+
+clang_tidy_test = lint_test(aspect = clang_tidy)

--- a/tools/lint/linters.bzl
+++ b/tools/lint/linters.bzl
@@ -2,7 +2,7 @@ load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
 load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
 
 clang_tidy = lint_clang_tidy_aspect(
-    binary = Label("//tools/lint:clang_tidy"),
+    binary = Label("//tools/lint:clang_tidy_runner"),
     configs = [Label("//:.clang-tidy")],
     lint_target_headers = True,
     angle_includes_are_system = False,


### PR DESCRIPTION
Another failed attempt. Now added a wrapper around the clang-tidy binary and passed it to aspect_rules_lint. The behavior is the same: the command failed and no lint output.