### PR TITLE
Update merge queue configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,7 @@ queue_rules:
     batch_max_wait_time: 5 minutes
     queue_conditions:
       - base = master
-      - draft = false
+      - -draft
       - label != do-not-merge
       - label != wip
       - check-success = check-dependencies
@@ -25,7 +25,7 @@ pull_request_rules:
   - name: Automatically queue PRs when reviews and check workflow pass
     conditions:
       - base = master
-      - draft = false
+      - -draft
       - label != do-not-merge
       - label != wip
       - check-success = check-dependencies

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,6 +5,9 @@ queue_rules:
     batch_max_wait_time: 5 minutes
     queue_conditions:
       - base = master
+      - draft = false
+      - label != do-not-merge
+      - label != wip
       - check-success = check-dependencies
       - check-success = prepare-workspace
       - check-success = format-check
@@ -22,6 +25,9 @@ pull_request_rules:
   - name: Automatically queue PRs when reviews and check workflow pass
     conditions:
       - base = master
+      - draft = false
+      - label != do-not-merge
+      - label != wip
       - check-success = check-dependencies
       - check-success = prepare-workspace
       - check-success = format-check


### PR DESCRIPTION
Update merge queue configuration. It won't queue if PR is in draft or any of the labels do-not-merge and wip are present.